### PR TITLE
Configuration du browse

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -49,4 +49,12 @@ webui.supported.locales = fr, en        # Bonne pratique de le spécifier ici. D
 # Browse #
 ##########
 
-# Voir la section "Browse Configuration" dans dspace.cfg
+# Configuration reprise depuis Papyrus 5.9 (dspace.cfg)
+webui.browse.index.1 = title:item:title:asc 
+webui.browse.index.2 = dateissued:item:dateissued:desc
+webui.browse.index.3 = author:metadata:dc.contributor.author\,dc.contributor:text
+webui.browse.index.4 = advisor:metadata:dc.contributor.advisor:text
+webui.browse.index.5 = subject:metadata:dc.subject.*:text
+webui.browse.index.6 = discipline:metadata:etd.degree.discipline:text
+webui.browse.index.7 = affiliation:metadata:dc.contributor.affiliation:text
+webui.browse.index.8 = titleindex:metadata:dc.title.*\,oaire.citationTitle:title:asc


### PR DESCRIPTION
Paramétrage du browse comme dans Papyrus 5.9. Pour voir le résultat, il faut utiliser la branche du même nom dans le frontend et réindexer:

bin/dspace index-discovery --build

Pour voir du contenu dans tous les index, il faut avoir les bonne métadonnées. Mais au pire ça donne des listes vides.