### PR TITLE
Ajout des métadonnées spécifiques à Papyrus dans le registre

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -58,3 +58,9 @@ webui.browse.index.5 = subject:metadata:dc.subject.*:text
 webui.browse.index.6 = discipline:metadata:etd.degree.discipline:text
 webui.browse.index.7 = affiliation:metadata:dc.contributor.affiliation:text
 webui.browse.index.8 = titleindex:metadata:dc.title.*\,oaire.citationTitle:text:asc
+
+############################
+# Registre des métadonnées #
+############################
+registry.metadata.load = udem-types.xml
+registry.metadata.load = etd-types.xml

--- a/dspace/config/registries/UdeM-types.xml
+++ b/dspace/config/registries/UdeM-types.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0"?>
+<!--
+  - UdeM-types.xml
+  -
+  - Des métdonnées locales pour l'UdeM (Papyrus).
+  - 
+  -->
+<dspace-dc-types>
+
+  <dspace-header>
+    <title>Registre des métadonnées spécifiques à l'UdeM / Papyrus</title>
+    <description>Ces métadonnées sont reprises depuis la base de données
+                  de l'instance 5.9 de Papyrus (elles n'étaient pas en fichiers
+                  de configuration)
+    </description>
+  </dspace-header>
+
+  <dc-schema>
+    <name>UdeM</name>
+    <namespace>http://www.bib.umontreal.ca/</namespace>
+  </dc-schema>
+
+  <dc-type>
+    <schema>UdeM</schema>
+    <element>NoteInterne</element>
+    <qualifier></qualifier>
+    <scope_note>
+      Notes internes que le déposant peut destiner aux vérificatuers.
+      Utilisé dans la Vitrine interdisciplinaire.
+    </scope_note>
+  </dc-type>
+
+  <dc-type>
+    <schema>UdeM</schema>
+    <element>ORCIDAuteurThese</element>
+    <qualifier></qualifier>
+    <scope_note>
+      Numero ORCID de l'auteur de la thèse.
+    </scope_note>
+  </dc-type>
+
+  <dc-type>
+    <schema>UdeM</schema>
+    <element>ReferenceFournieParDeposant</element>
+    <qualifier></qualifier>
+    <scope_note></scope_note>
+  </dc-type>
+
+  <dc-type>
+    <schema>UdeM</schema>
+    <element>TestEmbargoLift</element>
+    <qualifier></qualifier>
+    <scope_note>
+      Test to hold computed "lift date" of embargo.
+      TODO: toujours pertinent?
+    </scope_note>
+  </dc-type>
+
+  <dc-type>
+    <schema>UdeM</schema>
+    <element>TestEmbargoTerms</element>
+    <qualifier></qualifier>
+    <scope_note>
+      Test to hold the user-supplied embargo terms.
+      TODO: toujours pertinent?
+    </scope_note>
+  </dc-type>
+
+  <dc-type>
+    <schema>UdeM</schema>
+    <element>VersionRioxx</element>
+    <qualifier></qualifier>
+    <scope_note>
+      Indicate the status in the publication process.
+      Définition directement et exactement tirée de rioxx.
+    </scope_note>
+  </dc-type>
+
+  <dc-type>
+    <schema>UdeM</schema>
+    <element>cycle</element>
+    <qualifier></qualifier>
+    <scope_note>
+      Cycle (1er ou cycles supérieurs): s'applique aux travaux étudiants
+      et non aux TME.
+    </scope_note>
+  </dc-type>
+
+  <dc-type>
+    <schema>UdeM</schema>
+    <element>statut</element>
+    <qualifier></qualifier>
+    <scope_note>
+      Statut professeur ou étudiant, vitrine interdisciplinaire.
+    </scope_note>
+  </dc-type>
+
+</dspace-dc-types>

--- a/dspace/config/registries/dublin-core-types.xml
+++ b/dspace/config/registries/dublin-core-types.xml
@@ -123,6 +123,14 @@
     <scope_note></scope_note>
   </dc-type>
 
+  <!-- Ajout Papyrus -->
+  <dc-type>
+  	<schema>dc</schema>
+    <element>contributor</element>
+    <qualifier>affiliation</qualifier>
+    <scope_note>Affiliation de l'auteur (vitrine disciplinaire)</scope_note>
+  </dc-type>
+
   <dc-type>
 	<schema>dc</schema>
     <element>coverage</element>

--- a/dspace/config/registries/etd-types.xml
+++ b/dspace/config/registries/etd-types.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0"?>
+<!--
+  - etd-types.xml
+  -
+  - ETD-MS v1.1: an Interoperability Metadata Standard for Electronic
+  - Theses and Dissertations
+  -
+  - Dans Papyrus, on fait référence à la version 1.0 du standard mais ça
+  - ne semble pas avoir changé pour les 4 métadonnées qui nous concernent.
+  -
+  - Les notes en anglais sont extraites de:
+  -   https://ndltd.org/wp-content/uploads/2021/04/etd-ms-v1.1.html
+  - 
+  -->
+<dspace-dc-types>
+
+  <dspace-header>
+    <title>ETD - Interoperability Metadata Standard for
+                Electronic Theses and Dissertations</title>
+    <description>
+      Voir https://ndltd.org/wp-content/uploads/2021/04/etd-ms-v1.1.html
+    </description>
+  </dspace-header>
+
+  <dc-schema>
+    <name>etd</name>
+    <namespace>http://www.ndltd.org/standards/metadata/etdms/1.0/</namespace>
+  </dc-schema>
+
+  <dc-type>
+    <schema>etd</schema>
+    <element>degree</element>
+    <qualifier>discipline</qualifier>
+    <scope_note>
+      Area of study of the intellectual content of the document.
+      Usually, this will be the name of a program or department.
+    </scope_note>
+  </dc-type>
+
+  <dc-type>
+    <schema>etd</schema>
+    <element>degree</element>
+    <qualifier>grantor</qualifier>
+    <scope_note>
+      Institution granting the degree associated with the work.
+      Like other names and institutions, this field should be
+      entered in free text form as it appears on the title
+      page or equivalent, with a link to to an authority record
+      if available. See "Authority" section for more information.
+    </scope_note>
+  </dc-type>
+
+  <dc-type>
+    <schema>etd</schema>
+    <element>degree</element>
+    <qualifier>level</qualifier>
+    <scope_note>
+      Level of education associated with the document.
+      Three levels are valid:
+          0 Undergraduate (pre-masters)
+          1 Masters (pre-doctoral)
+          2 Doctoral (includes post-doctoral)
+    </scope_note>
+  </dc-type>
+
+  <dc-type>
+    <schema>etd</schema>
+    <element>degree</element>
+    <qualifier>name</qualifier>
+    <scope_note>
+      Name of the degree associated with the work as it appears within the work.
+      (example: Masters in Operations Research)
+    </scope_note>
+  </dc-type>
+
+</dspace-dc-types>


### PR DESCRIPTION
Les schémas ETD, UdeM et le dc.contributor.affiliation sont ajoutés. Pour voir les changements:

- Faire un checkout de la branche
- mvn package
- bin/dspace registry-loader -metadata dspace/config/registries/{udem|dublin-core|etd}-types.xml (pour les charger dans le base de données)
- dans l'interface d'admin, Registres, voir que ETD et UdeM sont là, ainsi que contributor.affiliation dans DC.

Le chargement dans la base de données est nécessaire...

Cela ne change pas le contenu, ni le fonctionnement, sauf lorsqu'on veut ajouter des documents.