### PR TITLE
Correction des commentaires en fin de ligne

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -38,12 +38,13 @@ include = local.local.cfg
 ##########################
 
 # Nom du site
-dspace.name = Papyrus   # Voir l'impact réel et déterminer le bon nom et s'il doit être local
+# Voir l'impact réel et déterminer le bon nom et s'il doit être local
+dspace.name = Papyrus
 
 # Default language for metadata values
-default.language = fr                   # Ne semble pas très utilisé
-default.locale = fr                     # Semble nécessaire pour que submission-forms_fr.xml fonctionne
-webui.supported.locales = fr, en        # Bonne pratique de le spécifier ici. Doit être cohérent avec config.prod.yml "languages"
+default.language = fr
+default.locale = fr
+webui.supported.locales = fr, en
 
 ##########
 # Browse #


### PR DESCRIPTION
On ne peut pas mettre un commentaire en fin de ligne dans un fichier .cfg, par exemple:
locale = fr # Notre langue par défaut

Toute la ligne est considérée pour la propriété locale.

Il y avait quelques occurrences de ces commentaires dans le fichier local.cfg.

Pour tester:
- simplement redémarrer et voir si DSPace fonctionne.