### PR TITLE
Retrait du vocabulaire SRSC du browse

### DIFF
--- a/dspace/config/local.cfg
+++ b/dspace/config/local.cfg
@@ -60,6 +60,9 @@ webui.browse.index.6 = discipline:metadata:etd.degree.discipline:text
 webui.browse.index.7 = affiliation:metadata:dc.contributor.affiliation:text
 webui.browse.index.8 = titleindex:metadata:dc.title.*\,oaire.citationTitle:text:asc
 
+# On retirer le browse du vaocabulaire SRSC, livré par défaut avec DSpace
+webui.browse.vocabularies.disabled = srsc
+
 ############################
 # Registre des métadonnées #
 ############################


### PR DESCRIPTION
Suite à l'ajout d'une configuration (voir https://github.com/DSpace/DSpace/pull/8948/commits/e55bc87c1aee8806befcd9dede575b258dfdfa9c), le vocabulaire contrôlé SRSC (livré par défaut avec DSpace) n'est plus présenté dans le "Parcourir"

Corrige aussi le bogue https://github.com/bibudem/papyrus-DSpace/issues/4 .

Pour tester, compiler et démarrer, voir si l'index est bien retiré du menu "Tout Papyrus".